### PR TITLE
FLAG-413: Remove no translate tags to make items translatable through transifex 

### DIFF
--- a/components/card-expandable/index.js
+++ b/components/card-expandable/index.js
@@ -42,10 +42,9 @@ const ExpandableCard = ({
                 onAfterOpen(cardData);
               }
             }}
-            className="notranslate"
           >
             {thumbnail && <Thumbnail src={thumbnail} alt={title} />}
-            <ContentWrapper className="notranslate">
+            <ContentWrapper>
               <Title>{title}</Title>
               {open && content && (
                 <Text small={small}>

--- a/components/card/index.js
+++ b/components/card/index.js
@@ -88,13 +88,9 @@ const Card = ({
                 `}
               />
             )}
-            {title && (
-              <PostTitle className="notranslate" large={large}>
-                {title}
-              </PostTitle>
-            )}
+            {title && <PostTitle large={large}>{title}</PostTitle>}
             {excerpt && (
-              <PostExcerpt className="notranslate" large={large}>
+              <PostExcerpt large={large}>
                 {ReactHtmlParser(excerpt)}
               </PostExcerpt>
             )}


### PR DESCRIPTION
## Description

This PR removes the `notranslate` classnames from the Card components, in order to make them translatable through Transifex.  

**Card components:**  
- `components/card`
- `components/card-expandable`

**Pages tested / affected:**   
- `/help/map`
- `/help/map/faqs`
- `/help/forest-watcher`
- `/help/forest-watcher/faqs`
- `/help/mapbuilder`
- `/help/faqs/grants-fellowships`
- `/help/use-gfw/monitor-forest-change`
- `/help/gfw-pro`
- `/help/gfw-pro/faqs`

## Notes

A couple pages linked in the JIRA task were not addressed: 
- `/help/mapbuilder/faqs`
  _no longer exists_  
- `/help/gfw-pro/user-support-questions`
  _I lack a GFW Pro account, but looking at the code it makes use of the same card components as all the other pages_

We still maintain a couple `notranslate` in the source, pertaining to actual articles' layouts (those are translated in WP), and the search component. The language switcher also maintains its `notranslate` class. 

## Tracking  

[FLAG-413](https://gfw.atlassian.net/browse/FLAG-413)