### PR TITLE
Switch domain from globalforestwatch.org to globalnaturewatch.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@emotion/styled": "^10.0.27",
     "@svgr/webpack": "^5.4.0",
     "@wordpress/api-fetch": "^3.19.0",
-    "@worldresources/gfw-components": "^3.5.20",
+    "@worldresources/gfw-components": "^3.5.21",
     "axios": "^0.20.0",
     "btoa": "^1.2.1",
     "buttercms": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@emotion/styled": "^10.0.27",
     "@svgr/webpack": "^5.4.0",
     "@wordpress/api-fetch": "^3.19.0",
-    "@worldresources/gfw-components": "^3.5.21",
+    "@worldresources/gfw-components": "^3.5.22",
     "axios": "^0.20.0",
     "btoa": "^1.2.1",
     "buttercms": "1.2.2",

--- a/utils/domain.js
+++ b/utils/domain.js
@@ -2,7 +2,7 @@
 // Node script during build, so it can't load an ES module. Once
 // globalnaturewatch.org is serving the app, this is the only line that
 // needs to change.
-const ROOT_DOMAIN = 'globalforestwatch.org';
+const ROOT_DOMAIN = 'globalnaturewatch.org';
 
 const GFW_DOMAIN = `https://www.${ROOT_DOMAIN}`;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,10 +2035,10 @@
     qs "^6.5.2"
     react-native-url-polyfill "^1.1.2"
 
-"@worldresources/gfw-components@^3.5.20":
-  version "3.5.20"
-  resolved "https://registry.yarnpkg.com/@worldresources/gfw-components/-/gfw-components-3.5.20.tgz#2a8adb802a94e0d1c6267dde810010dee28f656f"
-  integrity sha512-UmtKuY+B6hijHNEexS59dbrxTA18c25ULNW3ohGokf5oO5TSQylxDb37FJ7Vj/MzQiz+pgEfqFDGFzJxdOOTmw==
+"@worldresources/gfw-components@^3.5.21":
+  version "3.5.21"
+  resolved "https://registry.yarnpkg.com/@worldresources/gfw-components/-/gfw-components-3.5.21.tgz#14c85201f028f2a8b0b89f06b9f42f2a5a91a8e1"
+  integrity sha512-IKl14s935/yThYIrnXRf0dfXILP6Ka+w7GDIorn5AhiMHXQ6+sCiEDfE5hv98hDNVQ9A6iuEa70zcGzVQkknJw==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,10 +2035,10 @@
     qs "^6.5.2"
     react-native-url-polyfill "^1.1.2"
 
-"@worldresources/gfw-components@^3.5.21":
-  version "3.5.21"
-  resolved "https://registry.yarnpkg.com/@worldresources/gfw-components/-/gfw-components-3.5.21.tgz#14c85201f028f2a8b0b89f06b9f42f2a5a91a8e1"
-  integrity sha512-IKl14s935/yThYIrnXRf0dfXILP6Ka+w7GDIorn5AhiMHXQ6+sCiEDfE5hv98hDNVQ9A6iuEa70zcGzVQkknJw==
+"@worldresources/gfw-components@^3.5.22":
+  version "3.5.22"
+  resolved "https://registry.yarnpkg.com/@worldresources/gfw-components/-/gfw-components-3.5.22.tgz#efbe1f9643cf69b952016144f085207374fe38b0"
+  integrity sha512-2Tx8OUaBmhlAbbQEyhpavtGuKXOGAo/Qxf9qhI1rd7DJxwMeuTMH+Srd0QADgnaIK9uXqwUSzpGm0Lk6dMfavw==
   dependencies:
     "@artsy/fresnel" "^1.1.0"
     "@tippyjs/react" "^4.0.2"


### PR DESCRIPTION
globalforestwatch.org -> globalnaturewatch.org for root domain
upgrade wri/gfw-components to 3.5.22

Expected to break staging until the redirect is in place